### PR TITLE
Add notification to queue when a survey is stored

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Werkzeug==0.11.9
 requests==2.10.0
 pymongo==3.2.2
 voluptuous==0.8.11
+pika==0.10.0

--- a/settings.py
+++ b/settings.py
@@ -9,3 +9,13 @@ LOGGING_LEVEL = logging.DEBUG
 
 # Default to true, cast to boolean
 MONGODB_URL = os.getenv("MONGODB_URL", "mongodb://localhost:27017")
+
+RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'survey-notifications')
+
+RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
+    hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),
+    port=os.getenv('RABBITMQ_PORT', 5672),
+    user=os.getenv('RABBITMQ_DEFAULT_USER', 'rabbit'),
+    password=os.getenv('RABBITMQ_DEFAULT_PASS', 'rabbit'),
+    vhost=os.getenv('RABBITMQ_DEFAULT_VHOST', '%2f')
+)

--- a/settings.py
+++ b/settings.py
@@ -10,7 +10,7 @@ LOGGING_LEVEL = logging.DEBUG
 # Default to true, cast to boolean
 MONGODB_URL = os.getenv("MONGODB_URL", "mongodb://localhost:27017")
 
-RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'survey-notifications')
+RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'sdx-survey-notifications')
 
 RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
     hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),


### PR DESCRIPTION
sdx-store now appends a notification to a queue (sdx-survey-notifications) when a survey is stored - to drive the sdx-downstream service 

**Changes**
- Add a notification to the sdx-survey-notifications queue when a survey is stored

**How to test**
- Use the docker-compose setup from the dockers repo
- POST this JSON to `http://<docker_host>:85/responses`:

```
{
   "type": "uk.gov.ons.edc.eq:surveyresponse",
   "origin": "uk.gov.ons.edc.eq",
   "survey_id": "023",
   "version": "0.0.1",
   "collection": {
     "exercise_sid": "hfjdskf",
     "instrument_id": "0203",
     "period": "0216"
   },
   "submitted_at": "2016-03-12T10:39:40Z",
   "metadata": {
     "user_id": "789473423",
     "ru_ref": "12345678901A"
   },
   "data": {
     "11": "01/04/2016",
     "12": "31/10/2016",
     "20": "1800000",
     "51": "84",
     "52": "10",
     "53": "73",
     "54": "24",
     "50": "205",
     "22": "705000",
     "23": "900",
     "24": "74",
     "25": "50",
     "26": "100",
     "21": "60000",
     "27": "7400",
     "146": "some comment"
   }
}
```
- View the RabbitMQ admin UI at `http://<docker_host>:15672` to verify the sdx-survey-notifications queue is being appended to. 

**Depends on**
https://github.com/ONSdigital/dockers/pull/10

**Who can test**

Anyone but @ajmaddaford
