### PR TITLE
Check for invalid response and store in separate collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+build:
+	pip install -r requirements.txt
+
+test: build
+	pip install -r test_requirements.txt
+	flake8 --exclude ./lib/*
+	python3 -m unittest tests/*.py

--- a/server.py
+++ b/server.py
@@ -89,7 +89,10 @@ def save_response(bound_logger, survey_response):
     doc['survey_response'] = survey_response
     doc['added_date'] = datetime.utcnow()
 
-    invalid_flag = survey_response.get('invalid')
+    invalid_flag=False
+
+    if 'invalid' in survey_response:
+        invalid_flag = survey_response['invalid']
 
     try:
         result = get_db_responses(invalid_flag).insert_one(doc)

--- a/server.py
+++ b/server.py
@@ -89,7 +89,7 @@ def save_response(bound_logger, survey_response):
     doc['survey_response'] = survey_response
     doc['added_date'] = datetime.utcnow()
 
-    invalid_flag=False
+    invalid_flag = False
 
     if 'invalid' in survey_response:
         invalid_flag = survey_response['invalid']

--- a/server.py
+++ b/server.py
@@ -28,8 +28,11 @@ schema = Schema({
 })
 
 
-def get_db_responses():
+def get_db_responses(invalid_flag=False):
     mongo_client = MongoClient(app.config['MONGODB_URL'])
+    if invalid_flag:
+        return mongo_client.sdx_store.invalid_responses
+
     return mongo_client.sdx_store.responses
 
 
@@ -81,17 +84,20 @@ def json_response(content):
     return Response(output, mimetype='application/json')
 
 
-def save_response(survey_response, bound_logger):
+def save_response(bound_logger, survey_response):
     doc = {}
     doc['survey_response'] = survey_response
     doc['added_date'] = datetime.utcnow()
+
+    invalid_flag = survey_response.get('invalid')
+
     try:
-        result = get_db_responses().insert_one(doc)
-        return str(result.inserted_id)
+        result = get_db_responses(invalid_flag).insert_one(doc)
+        return str(result.inserted_id), invalid_flag
 
     except pymongo.errors.OperationFailure as e:
         bound_logger.error("Failed to store survey response", exception=str(e))
-        return None
+        return None, False
 
 
 def queue_notification(logger, mongo_id):
@@ -105,9 +111,13 @@ def do_save_response():
     metadata = survey_response['metadata']
     bound_logger = logger.bind(user_id=metadata['user_id'], ru_ref=metadata['ru_ref'])
 
-    inserted_id = save_response(survey_response, bound_logger)
+    inserted_id, invalid_flag = save_response(bound_logger, survey_response)
     if inserted_id is None:
         return server_error("Unable to save response")
+
+    if invalid_flag is True:
+        bound_logger.info("Invalid response saved, no notification queued", inserted_id=inserted_id)
+        return jsonify(result="false")
 
     queued = queue_notification(bound_logger, inserted_id)
     if queued is False:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -27,12 +27,12 @@ class TestStoreService(unittest.TestCase):
     def test_save_response_adds_doc_and_returns_id(self):
         mock_db = mongomock.MongoClient().db.collection
         with mock.patch('server.get_db_responses', return_value=mock_db):
-            mongo_id = server.save_response(test_message, None)
+            mongo_id, invalid_flag = server.save_response(None, json.loads(test_message))
             self.assertEqual(1, mock_db.count())
             self.assertIsNotNone(mongo_id)
 
     def test_response_not_saved_returns_500(self):
-        with mock.patch('server.save_response', return_value=None):
+        with mock.patch('server.save_response', return_value=(None,False)):
             r = self.app.post(self.endpoint, data=test_message)
             self.assertEqual(500, r.status_code)
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -32,7 +32,7 @@ class TestStoreService(unittest.TestCase):
             self.assertIsNotNone(mongo_id)
 
     def test_response_not_saved_returns_500(self):
-        with mock.patch('server.save_response', return_value=(None,False)):
+        with mock.patch('server.save_response', return_value=(None, False)):
             r = self.app.post(self.endpoint, data=test_message)
             self.assertEqual(500, r.status_code)
 


### PR DESCRIPTION
This allows invalid submissions to be stored in the db rather than logged out.

https://github.com/ONSdigital/sdx-collect/pull/141
https://github.com/ONSdigital/sdx-validate/pull/14