### PR TITLE
Feature/log version number on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Log version number on startup
 
 ### 1.4.0 2017-02-17
   - Add new `/invalid-responses` endpoint for viewing invalid submissions

--- a/server.py
+++ b/server.py
@@ -13,6 +13,8 @@ from structlog import wrap_logger
 from queue_publisher import QueuePublisher
 import os
 
+__version__ = "1.4.0"
+
 logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
 logger = wrap_logger(logging.getLogger(__name__))
 app = Flask(__name__)
@@ -261,5 +263,6 @@ def healthcheck():
 
 if __name__ == '__main__':
     # Startup
+    logger.info("Current version: {}".format(__version__))
     port = int(os.getenv("PORT"))
     app.run(debug=True, host='0.0.0.0', port=port)

--- a/server.py
+++ b/server.py
@@ -263,6 +263,6 @@ def healthcheck():
 
 if __name__ == '__main__':
     # Startup
-    logger.info("Current version: {}".format(__version__))
+    logger.info("Starting server", version=__version__)
     port = int(os.getenv("PORT"))
     app.run(debug=True, host='0.0.0.0', port=port)


### PR DESCRIPTION
This is a pull request to add functionality that logs the current version number on service startup. The `__version__` variable in `server.py` contains the current release value, which will need to be manually updated on a new release being cut. The version is logged at INFO level.