### PR TITLE
Feature/persist queue publishers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Persist QueuePublishers
 
 ### 1.4.1 2017-03-15
   - Log version number on startup

--- a/queue_publisher.py
+++ b/queue_publisher.py
@@ -1,5 +1,36 @@
 import pika
 
+import settings
+
+
+class Publishers():
+    """Persists the QueuePublisher objects instantiated for CTP, CORA and
+       CS endpoints.
+
+    Args:
+        logger (Logging.logger): Variable holding a logger object.
+
+    Attributes:
+        cora (QueuePublisher): Cora queue QueuePublisher object.
+        ctp (QueuePublisher): CTP queue QueuePublisher object.
+        cs (QueuePublisher): CS queue QueuePublisher object.
+        """
+
+    def __init__(self, logger):
+        self.logger = logger
+
+        self.cs = QueuePublisher(self.logger,
+                                 settings.RABBIT_URLS,
+                                 settings.RABBIT_CS_QUEUE)
+
+        self.ctp = QueuePublisher(self.logger,
+                                  settings.RABBIT_URLS,
+                                  settings.RABBIT_CS_QUEUE)
+
+        self.cora = QueuePublisher(self.logger,
+                                   settings.RABBIT_URLS,
+                                   settings.RABBIT_CORA_QUEUE)
+
 
 class QueuePublisher(object):
 

--- a/queue_publisher.py
+++ b/queue_publisher.py
@@ -3,7 +3,7 @@ import pika
 import settings
 
 
-class Publishers():
+class Publisher():
     """Persists the QueuePublisher objects instantiated for CTP, CORA and
        CS endpoints.
 
@@ -25,7 +25,7 @@ class Publishers():
 
         self.ctp = QueuePublisher(self.logger,
                                   settings.RABBIT_URLS,
-                                  settings.RABBIT_CS_QUEUE)
+                                  settings.RABBIT_CTP_QUEUE)
 
         self.cora = QueuePublisher(self.logger,
                                    settings.RABBIT_URLS,

--- a/server.py
+++ b/server.py
@@ -10,7 +10,7 @@ from voluptuous import Schema, Coerce, All, Range, MultipleInvalid
 from bson.objectid import ObjectId
 from bson.errors import InvalidId
 from structlog import wrap_logger
-from queue_publisher import Publishers
+from queue_publisher import Publisher
 import os
 
 __version__ = "1.4.1"
@@ -19,7 +19,7 @@ logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT
 logger = wrap_logger(logging.getLogger(__name__))
 app = Flask(__name__)
 app.config['MONGODB_URL'] = settings.MONGODB_URL
-publishers = Publishers(logger)
+publisher = Publisher(logger)
 
 schema = Schema({
     'survey_id': str,
@@ -122,11 +122,11 @@ def do_save_response():
         return jsonify(result="false")
 
     if survey_response['survey_id'] == 'census':
-        queued = publishers.ctp.publish_message(inserted_id)
+        queued = publisher.ctp.publish_message(inserted_id)
     elif survey_response['survey_id'] == '144':
-        queued = publishers.cora.publish_message(inserted_id)
+        queued = publisher.cora.publish_message(inserted_id)
     else:
-        queued = publishers.cs.publish_message(inserted_id)
+        queued = publisher.cs.publish_message(inserted_id)
 
     if queued is False:
         return server_error("Unable to queue notification")
@@ -230,11 +230,11 @@ def do_queue():
     response = json.loads(result.response[0].decode('utf-8'))
 
     if response['survey_response']['survey_id'] == 'census':
-        queued = publishers.ctp.publish_message(mongo_id)
+        queued = publisher.ctp.publish_message(mongo_id)
     elif response['survey_response']['survey_id'] == '144':
-        queued = publishers.cora.publish_message(mongo_id)
+        queued = publisher.cora.publish_message(mongo_id)
     else:
-        queued = publishers.cs.publish_message(mongo_id)
+        queued = publisher.cs.publish_message(mongo_id)
 
     if queued is False:
         return server_error("Unable to queue notification")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -42,14 +42,14 @@ class TestStoreService(unittest.TestCase):
     def test_queue_fails_returns_500(self):
         mock_db = mongomock.MongoClient().db.collection
         with mock.patch('server.get_db_responses', return_value=mock_db):
-            with mock.patch('server.queue_cs_notification', return_value=False):
+            with mock.patch('server.publishers.cs.publish_message', return_value=False):
                 r = self.app.post(self.endpoint, data=test_message)
                 self.assertEqual(500, r.status_code)
 
     def test_queue_succeeds_returns_200(self):
         mock_db = mongomock.MongoClient().db.collection
         with mock.patch('server.get_db_responses', return_value=mock_db):
-            with mock.patch('server.queue_cs_notification', return_value=True):
+            with mock.patch('server.publishers.cs.publish_message', return_value=True):
                 r = self.app.post(self.endpoint, data=test_message)
                 self.assertEqual(200, r.status_code)
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -42,14 +42,14 @@ class TestStoreService(unittest.TestCase):
     def test_queue_fails_returns_500(self):
         mock_db = mongomock.MongoClient().db.collection
         with mock.patch('server.get_db_responses', return_value=mock_db):
-            with mock.patch('server.publishers.cs.publish_message', return_value=False):
+            with mock.patch('server.publisher.cs.publish_message', return_value=False):
                 r = self.app.post(self.endpoint, data=test_message)
                 self.assertEqual(500, r.status_code)
 
     def test_queue_succeeds_returns_200(self):
         mock_db = mongomock.MongoClient().db.collection
         with mock.patch('server.get_db_responses', return_value=mock_db):
-            with mock.patch('server.publishers.cs.publish_message', return_value=True):
+            with mock.patch('server.publisher.cs.publish_message', return_value=True):
                 r = self.app.post(self.endpoint, data=test_message)
                 self.assertEqual(200, r.status_code)
 


### PR DESCRIPTION
Queue publishers are now persisted in a `Publisher` object and can be accessed via their corresponding method calls, i.e. :
  - `publisher.cora`
  - `publisher.cs`
  - `publisher.ctp`