### PR TITLE
Catch index exception when looking at result items

### DIFF
--- a/server.py
+++ b/server.py
@@ -281,8 +281,12 @@ def do_get_responses():
 def do_get_response(tx_id):
     result = get_responses(tx_id=tx_id)
     if result:
-        r = object_as_dict(result.items[0])['data']
-        return jsonify(r)
+        try:
+            r = object_as_dict(result.items[0])['data']
+            return jsonify(r)
+        except IndexError as e:
+            logger.error('Empty items list in result.', error=e)
+            return jsonify({}), 404
     else:
         return jsonify({}), 404
 


### PR DESCRIPTION
Currently, in some cases, the `items` attribute of results can be None. In this case, an IndexError is raised. This pull request introduces a try except block that catches these errors, logs to stdout, and returns an empty 404 response.