### PR TITLE
Update error handling to correctly return 500 errors

### DIFF
--- a/server.py
+++ b/server.py
@@ -3,6 +3,7 @@ import json
 import logging
 import logging.handlers
 import os
+import sys
 
 from flask import jsonify, Flask, Response, request
 from flask_sqlalchemy import SQLAlchemy
@@ -25,7 +26,6 @@ publisher = Publisher(logger)
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = settings.DB_URI
-logger.debug(app.config['SQLALCHEMY_DATABASE_URI'])
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = settings.SQLALCHEMY_TRACK_MODIFICATIONS
 
 db = SQLAlchemy(app=app)
@@ -90,6 +90,27 @@ def _get_value(key):
     value = os.getenv(key)
     if not value:
         raise ValueError("No value set for " + key)
+
+
+def check_default_env_vars():
+    env_vars = ["SDX_STORE_RABBIT_CS_QUEUE", "SDX_STORE_RABBIT_CTP_QUEUE",
+                "SDX_STORE_RABBIT_CORA_QUEUE", "SDX_STORE_RABBITMQ_HOST",
+                "SDX_STORE_RABBITMQ_PORT", "SDX_STORE_RABBITMQ_DEFAULT_USER",
+                "SDX_STORE_RABBITMQ_DEFAULT_PASS",
+                "SDX_STORE_RABBITMQ_DEFAULT_VHOST", "SDX_STORE_RABBITMQ_HOST2",
+                "SDX_STORE_RABBITMQ_PORT2",
+                ]
+
+    missing = False
+    for i in env_vars:
+        try:
+            _get_value(i)
+        except ValueError as e:
+            logger.error("Unable to start service", error=e)
+            missing = True
+
+    if missing is True:
+        sys.exit(1)
 
 
 def create_tables():
@@ -162,8 +183,9 @@ def save_response(bound_logger, survey_response):
         try:
             db.session.add(response)
             db.session.commit()
-        except SQLAlchemyError:
-            return server_error("Unable to save response")
+        except SQLAlchemyError as e:
+            bound_logger.info("Unable to save response", error=e)
+            return server_error("Returning 500 - unable to save response to database")
         else:
             bound_logger.info("Response saved",
                               invalid=invalid)
@@ -214,10 +236,13 @@ def do_save_response():
 
     publisher.logger = bound_logger
 
-    invalid = save_response(bound_logger, survey_response)
+    try:
+        invalid = save_response(bound_logger, survey_response)
+    except SQLAlchemyError as e:
+        return server_error("Database error")
 
     if invalid is True:
-        return jsonify(result="false")
+        return jsonify(invalid)
 
     tx_id = survey_response['tx_id']
 
@@ -305,5 +330,6 @@ def healthcheck():
 if __name__ == '__main__':
     # Startup
     logger.info("Starting server", version=__version__)
+    check_default_env_vars()
     port = int(os.getenv("PORT"))
     app.run(debug=True, host='0.0.0.0', port=port)

--- a/server.py
+++ b/server.py
@@ -186,7 +186,7 @@ def save_response(bound_logger, survey_response):
             db.session.commit()
         except SQLAlchemyError as e:
             bound_logger.info("Unable to save response", error=e)
-            return server_error("Returning 500 - unable to save response to database")
+            raise SQLAlchemyError
         else:
             bound_logger.info("Response saved",
                               invalid=invalid)

--- a/server.py
+++ b/server.py
@@ -169,6 +169,7 @@ def object_as_dict(obj):
 
 
 def save_response(bound_logger, survey_response):
+    bound_logger.info("Saving response")
     invalid = survey_response.get("invalid")
 
     try:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -80,7 +80,8 @@ class TestStoreService(unittest.TestCase):
         self.assertEqual(True, invalid)
 
     def test_response_not_saved_returns_500(self):
-        with mock.patch('server.save_response', return_value=(None, False)):
+        with mock.patch('server.db.session.commit') as db_mock:
+            db_mock.side_effect = SQLAlchemyError
             r = self.app.post(self.endpoints['responses'], data=test_message)
             self.assertEqual(500, r.status_code)
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -62,10 +62,6 @@ class TestStoreService(unittest.TestCase):
         db.drop_all()
         self.postgres.stop()
 
-    def test_missing_envvar_raises_value_error(self):
-        with self.assertRaises(ValueError):
-            server._get_value('TEST')
-
     # /responses POST
     def test_empty_post_request(self):
         r = self.app.post(self.endpoints['responses'])


### PR DESCRIPTION
sdx-store is not currently returning 500 responses in all applicable cases. This causes errors where other sdx* services assume that a tx-id has been stored correctly, but in fact has not been persisted to the database.

This change escalates any SQLAlchemy errors to the relevant flask view function and returns the correct `server_error` response to the calling service. There are also changes to the test suite to reflect this and better capture successful returning of errors. Logging has also been updated to make it more searchable in splunk output.