### PR TITLE
Remove sdx-common logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
  - Removed SDX common clone in docker
  - Begin using PyTest as default test runner
+ - Remove sdx-common logging
 
 ### 3.0.0 2017-09-11
   - Ensure integrity and version of library dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,9 +42,6 @@ psycopg2==2.7.1 \
 structlog==16.1.0 \
     --hash=sha256:a8cc45c208c6b251031ec223940552eccd97dbdb322474e0c4ec9e50f76a225a \
     --hash=sha256:b44dfaadcbab84e6bb97bd9b263f61534a79611014679757cd93e2359ee7be01
-sdx-common==0.7.2 \
-    --hash=sha256:1eace2a6dd2b7eef0c052f71a3ddf2e6d81b281c3a31fc9560dbf307e2a0e4cb \
-    --hash=sha256:6afc473b6405a0b66889ec0ccab6ce321c3a638e20bd5f2cbada6561d747ffab
 voluptuous==0.9.3 \
     --hash=sha256:ed5a11fda273754caabb6becd5fe172ee2621cd2c8ff8279433173bb7b0ec568
 cryptography==1.7.1 \

--- a/server.py
+++ b/server.py
@@ -1,11 +1,10 @@
 from datetime import datetime
 import json
-import logging.handlers
+import logging
 import os
 
 from flask import jsonify, Flask, Response, request
 from flask_sqlalchemy import SQLAlchemy
-from sdx.common.logger_config import logger_initial_config
 from sqlalchemy import inspect, select, Integer, String
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
@@ -18,7 +17,10 @@ import settings
 
 __version__ = "3.0.0"
 
-logger_initial_config(service_name='sdx-store', log_level=settings.LOGGING_LEVEL)
+logging.basicConfig(format=settings.LOGGING_FORMAT,
+                    datefmt="%Y-%m-%dT%H:%M:%S",
+                    level=settings.LOGGING_LEVEL)
+
 logger = wrap_logger(logging.getLogger(__name__))
 
 app = Flask(__name__)

--- a/settings.py
+++ b/settings.py
@@ -3,6 +3,7 @@ import logging
 
 
 LOGGING_LEVEL = logging.getLevelName(os.getenv('LOGGING_LEVEL', 'DEBUG'))
+LOGGING_FORMAT = "%(asctime)s.%(msecs)06dZ|%(levelname)s: sdx-store: %(message)s"
 
 DB_HOST = os.getenv('SDX_STORE_POSTGRES_HOST', '0.0.0.0')
 DB_PORT = os.getenv('SDX_STORE_POSTGRES_PORT', '5432')


### PR DESCRIPTION
## What? and Why?
> What does this pull request change/fix? Why was it necessary? Remove logging via sdx-common and bring it back into the repo now that sdx-common is no longer used.

## Checklist
  - [ ] CHANGELOG.md updated? (if required) Y
