### PR TITLE
Make reprocessing Invalid responses easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
   - Add startup log with version
+  - Remove 'invalid' key from stored data
+  - Add script that resets invalid stored data
 
 ### 3.5.0 2018-10-22
   - Add MD5 hash to GET /responses

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,3 +9,15 @@ an excel file with them in.
  - Get the survey id and period that you wish to see the comments for
  - Run the script with ```python3 export_comments.py <survey_id> <period>``` (assuming you're in a virtual environment that has been set up correctly)
      - Example usage ```python3 export_comments.py 023 201807```
+    
+       
+     
+## Reset Invalid Store Data (reset_invalid_store_data.py)
+### Description
+This is used to remove the 'invalid' key from the stored data and set the store's invalid column to False so that the response can be reprocessed. 
+The 'invalid' key is added by sdx-collect to identify invalid responses and was previously stored along with the response data.
+This 'invalid' key in the stored data prohibits the reprocessing of the response and so in future will not be stored however for older responses it needs to be removed.
+ 
+### Usage
+ - Get the tx_ids for each response that you need to reset and put one per line within the file tx_ids.
+ - Run the script with ```python3 reset_invalid_store_data.py``` (assuming you're in a virtual environment that has been set up correctly)

--- a/scripts/reset_invalid_store_data.py
+++ b/scripts/reset_invalid_store_data.py
@@ -1,0 +1,94 @@
+import os
+import sys
+
+parent_dir_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(parent_dir_path)
+
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.types import Boolean
+from sqlalchemy.dialects.postgresql import JSONB, UUID, TIMESTAMP
+
+import settings
+
+try:
+    db = create_engine(settings.DB_URI)
+    Session = sessionmaker(db)
+    session = Session()
+    base = declarative_base()
+except SQLAlchemyError as e:
+    print(e)
+    raise
+
+
+class SurveyResponse(base):
+    __tablename__ = 'responses'
+    tx_id = Column("tx_id",
+                   UUID,
+                   primary_key=True)
+
+    ts = Column("ts",
+                TIMESTAMP(timezone=True))
+
+    invalid = Column("invalid",
+                     Boolean,
+                     default=False)
+
+    data = Column("data", JSONB)
+
+    def __init__(self, tx_id, invalid, data):
+        self.tx_id = tx_id
+        self.invalid = invalid
+        self.data = data
+
+    def __repr__(self):
+        return '<SurveyResponse {}>'.format(self.tx_id)
+
+    def to_dict(self):
+        return {c.name: getattr(self, c.name) for c in self.__table__.columns}
+
+
+def reset_store_data(tx_id):
+    """Remove invalid key from data and
+       set invalid column to False"""
+
+    records = session.query(SurveyResponse).filter(
+        SurveyResponse.tx_id == tx_id)
+
+    for record in records:
+        if record.data.get('invalid'):
+            record.data.pop('invalid')  # Remove 'invalid' key
+
+        response = SurveyResponse(tx_id=tx_id,
+                                  invalid=False,  # Set invalid column to False
+                                  data=record.data)
+
+        save_updated_record(response)
+        print("TX_ID {} updated".format(tx_id))
+
+
+def save_updated_record(response):
+    try:
+        session.merge(response)
+        session.commit()
+    except (SQLAlchemyError, IntegrityError) as e:
+        session.rollback()
+        raise e
+
+
+if __name__ == "__main__":
+    with open('tx_ids', 'r') as fp:
+        lines = list(fp)
+
+    if not lines:
+        sys.exit("No tx_ids in file, exiting script")
+    for tx_id in lines:
+        try:
+            reset_store_data(tx_id.rstrip())
+        except (SQLAlchemyError, IntegrityError) as e:
+            print("TX_ID {} FAILED update".format(tx_id))
+            print(e)
+            raise

--- a/scripts/tx_ids
+++ b/scripts/tx_ids
@@ -1,0 +1,1 @@
+# Delete this line and replace with tx_ids that need amending, with 1 per line

--- a/server.py
+++ b/server.py
@@ -170,7 +170,10 @@ def object_as_dict(obj):
 
 def save_response(bound_logger, survey_response):
     bound_logger.info("Saving response")
+
     invalid = survey_response.get("invalid")
+    if invalid:
+        survey_response.pop("invalid")
 
     try:
         tx_id = survey_response["tx_id"]
@@ -188,9 +191,12 @@ def save_response(bound_logger, survey_response):
 
 def save_feedback_response(bound_logger, survey_feedback_response):
     bound_logger.info("Saving feedback response")
-    invalid = survey_feedback_response.get("invalid")
     survey = survey_feedback_response.get("survey_id")
     period = survey_feedback_response.get("collection", {}).get("period")
+
+    invalid = survey_feedback_response.get("invalid")
+    if invalid:
+        survey_feedback_response.pop("invalid")
 
     feedback_response = FeedbackResponse(invalid=invalid,
                                          data=survey_feedback_response,


### PR DESCRIPTION
Do not store 'invalid' with response data
"invalid": True is added by sdx-collect to identify invalid responses
This however should not be stored as it's not part of the initial response

New Script that will remove 'invalid' key from stored data and change invalid column to false for specified tx_ids

## Checklist
  - [ ] CHANGELOG.md updated? (if required)
