### PR TITLE
Fixed reprocessing script to work with postgres 9.6.2

### DIFF
--- a/scripts/reset_invalid_store_data.py
+++ b/scripts/reset_invalid_store_data.py
@@ -11,6 +11,7 @@ from sqlalchemy import Column
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.types import Boolean
 from sqlalchemy.dialects.postgresql import JSONB, UUID, TIMESTAMP
+from sqlalchemy.ext.mutable import MutableDict
 
 import settings
 
@@ -37,7 +38,7 @@ class SurveyResponse(base):
                      Boolean,
                      default=False)
 
-    data = Column("data", JSONB)
+    data = Column("data", MutableDict.as_mutable(JSONB))
 
     def __init__(self, tx_id, invalid, data):
         self.tx_id = tx_id


### PR DESCRIPTION
## What? and Why?
https://trello.com/c/dtKXlGVB/2417-reprocess-submissions-with-startedat-field-before-sdx-accepted-that-field
Needed to fix the script as it worked against postgres 9.6.11, but not with 9.6.2, which is what we use in preprod/prod.

## Checklist
  - [ ] CHANGELOG.md updated? (if required)
