### PR TITLE
Validate tx_id in GET endpoint is valid UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Fix /invalid-responses endpoint
+  - Validate tx_id is a real uuid in the /responses/<tx_id> endpoint
 
 ### 3.7.0 2018-12-12
   - Remove 'invalid' key from stored data

--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import os
+import uuid
 
 from flask import jsonify, Flask, request
 from flask_sqlalchemy import SQLAlchemy
@@ -265,10 +266,10 @@ def do_save_response():
                                          survey_id=survey_response.get("survey_id"))
         try:
             save_feedback_response(bound_logger, survey_response)
-        except SQLAlchemyError:
-            return server_error("Database error")
         except IntegrityError:
             return server_error("Integrity error")
+        except SQLAlchemyError:
+            return server_error("Database error")
     else:
         try:
             metadata = survey_response['metadata']
@@ -280,10 +281,10 @@ def do_save_response():
 
         try:
             invalid = save_response(bound_logger, survey_response)
-        except SQLAlchemyError:
-            return server_error("Database error")
         except IntegrityError:
             return server_error("Integrity error")
+        except SQLAlchemyError:
+            return server_error("Database error")
 
         if invalid:
             return jsonify(invalid)
@@ -310,6 +311,11 @@ def do_get_responses():
 
 @app.route('/responses/<tx_id>', methods=['GET'])
 def do_get_response(tx_id):
+    try:
+        uuid.UUID(tx_id, version=4)
+    except ValueError:
+        raise InvalidUsageError("tx_id supplied is not a valid UUID", 400)
+
     result = get_responses(tx_id=tx_id)
     if result:
         try:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -95,9 +95,18 @@ class TestStoreService(unittest.TestCase):
         assert r.status_code == 200
 
     # /responses/<tx_id> GET
+    def test_get_id_returns_400_if_not_a_valid_uuid(self):
+        """Endpoint should return 400 if the tx_id isn't a valid uuid formatted uuid"""
+        r = self.app.get(self.endpoints['responses'] + '/123')
+        assert r.status_code == 400
+
+        r = self.app.get(self.endpoints['responses'] + '/ed7d29ed-612b-e981-d5ed-0e2e3c9951e3\n')
+        assert r.status_code == 400
+
     def test_get_id_returns_404_if_not_stored(self):
-        r = self.app.get(self.endpoints['responses'] + '/x')
-        self.assertEqual(404, r.status_code)
+        """Endpoint should return 404 if the tx_id isn't found in the database"""
+        r = self.app.get(self.endpoints['responses'] + '/35e5062b-7041-4030-8ff5-122b3ef216a9')
+        assert r.status_code == 404
 
     def test_get_valid_id_returns_id_and_200(self):
         expected_id = self.test_message_json['tx_id']


### PR DESCRIPTION
## What? and Why?
https://trello.com/c/Wk0SbeKC/431-validate-uuid-when-getting-a-submission-from-sdx-store

When the tx_id in the /responses/tx_id endpoint wasn't a valid uuid, the error message returned was fairly unclear.  Validating it before it attempts to search should make diagnosing errors easier.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
