### PR TITLE
Fix /invalid-responses endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
+dist: xenial
 python:
+    - "3.7"
     - "3.6"
     - "3.5"
     - "3.4"
@@ -14,10 +16,10 @@ before_script:
     - psql -c 'create database test;' -U postgres
     - psql -c "grant all privileges on database test to postgres;" -U postgres
 script:
+    - flake8 --exclude lib
     - pytest -v tests/ --cov=server --cov-report html
 services:
     - postgresql
-dist: trusty
 after_success:
     - codecov
 addons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Fix /invalid-responses endpoint
 
 ### 3.7.0 2018-12-12
   - Remove 'invalid' key from stored data

--- a/server.py
+++ b/server.py
@@ -262,7 +262,7 @@ def do_save_response():
 
     if response_type.find("feedback") != -1:
         bound_logger = bound_logger.bind(response_type="feedback",
-                                   survey_id=survey_response.get("survey_id"))
+                                         survey_id=survey_response.get("survey_id"))
         try:
             save_feedback_response(bound_logger, survey_response)
         except SQLAlchemyError:
@@ -276,7 +276,7 @@ def do_save_response():
             raise InvalidUsageError("Missing metadata. Unable to save response", 400)
 
         bound_logger = bound_logger.bind(user_id=metadata.get('user_id'),
-                                   ru_ref=metadata.get('ru_ref'))
+                                         ru_ref=metadata.get('ru_ref'))
 
         try:
             invalid = save_response(bound_logger, survey_response)
@@ -293,12 +293,8 @@ def do_save_response():
 
 @app.route('/invalid-responses', methods=['GET'])
 def do_get_invalid_responses():
-    responses = get_responses(invalid=True)
-
-    if responses:
-        jsonify(responses)
-    else:
-        return jsonify({}), 404
+    page = get_responses(invalid=True)
+    return jsonify([item.to_dict() for item in page.items])
 
 
 @app.route('/responses', methods=['GET'])
@@ -321,11 +317,9 @@ def do_get_response(tx_id):
             response = jsonify(result_dict)
             response.headers['Content-MD5'] = hashlib.md5(response.data).hexdigest()
             return response
-
         except IndexError:
             logger.exception('Empty items list in result.')
             return jsonify({}), 404
-
     else:
         return jsonify({}), 404
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -19,7 +19,7 @@ from server import db, InvalidUsageError, logger
 class TestStoreService(unittest.TestCase):
     endpoints = {
         'responses': '/responses',
-        'invalid': '/invalid_responses',
+        'invalid': '/invalid-responses',
         'queue': '/queue',
         'healthcheck': '/healthcheck'
     }
@@ -88,6 +88,11 @@ class TestStoreService(unittest.TestCase):
 
         db.session.remove()
         db.drop_all()
+
+    # /invalid-responses GET
+    def test_get_invalid_responses_returns_200(self):
+        r = self.app.get(self.endpoints['invalid'])
+        assert r.status_code == 200
 
     # /responses/<tx_id> GET
     def test_get_id_returns_404_if_not_stored(self):


### PR DESCRIPTION
## What? and Why?
https://trello.com/c/4OOYnWFK/429-fix-sdx-store-invalid-responses-endpoint

The /invalid-responses was broken for a while, but because it was seldom used, we didn't know.  This fixes it and adds an integration test so we can know if it breaks again.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
