### PR TITLE
Add info to error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Add python 3.8 to travis builds
+  - Add url to logging metadata on an InvalidUsageError exception
 
 ### 3.9.2 2019-09-26
   - Update packages to bring them in line with other SDX repos

--- a/server.py
+++ b/server.py
@@ -154,7 +154,7 @@ def server_error(error):
 
 @app.errorhandler(InvalidUsageError)
 def invalid_usage_error(error):
-    logger.error(error.message, status=400, payload=error.payload)
+    logger.error(error.message, status=400, payload=error.payload, url=request.url)
     response = jsonify(error.to_dict())
     response.status_code = error.status_code
     return response


### PR DESCRIPTION
## What? and Why?
During an issue, /responses/<tx_id> was being hit with an invalid tx_id, but we couldn't tell what the tx_id it was bieng given in the logs easily.  This will make it easier to figure out and will give extra context for any InvalidUsageError we get in the future

## Checklist
  - [x] CHANGELOG.md updated? (if required)
