### PR TITLE
release 3.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### Unreleased
+
+### 3.9.5 2019-12-18
   - Added delete old end point
 
 ### 3.9.4 2019-12-13

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,7 @@ from structlog import wrap_logger
 
 import settings
 
-__version__ = "3.9.4"
+__version__ = "3.9.5"
 
 logging.basicConfig(format=settings.LOGGING_FORMAT,
                     datefmt="%Y-%m-%dT%H:%M:%S",


### PR DESCRIPTION
## What? and Why?
> Release 3.9.5
Adds endpoint so that sdx-store can be called to delete old records
## Checklist
  - [x] CHANGELOG.md updated? (if required)
