### PR TITLE
Fix comments script 009

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Amend comment script to display respondent entered comments for MBS (009)
   - Added delete old end point
 
 ### 3.9.4 2019-12-13

--- a/scripts/export_comments.py
+++ b/scripts/export_comments.py
@@ -32,7 +32,7 @@ def create_comments_excel_file(survey_id, period, submissions):
     ws = workbook.active
 
     for submission in submissions:
-        comment = submission.data['data'].get('146')
+        comment = get_comment_text(submission)
 
         boxes_selected = ""
         for key in ('146' + letter for letter in ascii_lowercase[0:]):
@@ -65,6 +65,14 @@ def get_all_submissions(survey_id, period):
     records = survey_records.filter(SurveyResponse.data['collection']['period'].astext == period).all()
     print(f"Retrieved {len(records)} submissions")
     return records
+
+def get_comment_text(submission):
+    """Returns the respondent typed text from a submission.  The qcode for this text will be different depending
+    on the survey
+    """
+    if submission.data['survey_id'] == '009':
+        return submission.data['data'].get('146h')
+    return submission.data['data'].get('146')
 
 
 if __name__ == "__main__":

--- a/scripts/export_comments.py
+++ b/scripts/export_comments.py
@@ -66,6 +66,7 @@ def get_all_submissions(survey_id, period):
     print(f"Retrieved {len(records)} submissions")
     return records
 
+
 def get_comment_text(submission):
     """Returns the respondent typed text from a submission.  The qcode for this text will be different depending
     on the survey


### PR DESCRIPTION
## What? and Why?
For MBS (009), the free text comments are in 146h instead of 146.  This changes the comment generation script to get the free text comment from a variety of qcodes based on survey_id instead of only getting it from 146.

## How to test
- Generate some submissions in console (make a note of the survey_id and period)
- In sdx-store do `python /scripts/export.comments.py 009 201605`


## Checklist
  - [x] CHANGELOG.md updated? (if required)
