### PR TITLE
Exporting mwss comments

### DIFF
--- a/scripts/export_comments.py
+++ b/scripts/export_comments.py
@@ -67,7 +67,6 @@ def create_comments_excel_file(survey_id, period, submissions):
         ws.cell(row, 3, boxes_selected)
         ws.cell(row, 4, comment)
 
-
     ws.cell(1, 1, f"Survey ID: {survey_id}")
     ws.cell(1, 2, f"Comments found: {surveys_with_comments_count}")
     if survey_id == '134':

--- a/scripts/export_comments.py
+++ b/scripts/export_comments.py
@@ -58,7 +58,11 @@ def create_comments_excel_file(survey_id, period, submissions):
                 ws.cell(row, 8, submission.data['data']['300w4'])
             if '300w5' in submission.data['data']:
                 ws.cell(row, 9, submission.data['data']['300w5'])
-            checkboxes = ['91w', '92w1', '92w2', '94w1', '94w2', '95w', '96w', '97w', '91f', '92f1', '92f2', '94f1', '94f2', '95f', '96f', '97f', '191m', '192m1', '192m2', '194m1', '194m2', '195m', '196m', '197m', '191w4', '192w41', '192w42', '194w41', '194w42', '195w4', '196w4', '197w4', '191w5', '192w51', '192w52', '194w51', '194w52', '195w5', '196w5', '197w5']
+            checkboxes = ['91w', '92w1', '92w2', '94w1', '94w2', '95w', '96w', '97w',
+                          '91f', '92f1', '92f2', '94f1', '94f2', '95f', '96f', '97f',
+                          '191m', '192m1', '192m2', '194m1', '194m2', '195m', '196m', '197m',
+                          '191w4', '192w41', '192w42', '194w41', '194w42', '195w4', '196w4',
+                          '197w4', '191w5', '192w51', '192w52', '194w51', '194w52', '195w5', '196w5', '197w5']
             filled_checkboxes = ""
             for checkbox in checkboxes:
                 if checkbox in submission.data['data']:

--- a/scripts/export_comments.py
+++ b/scripts/export_comments.py
@@ -47,9 +47,29 @@ def create_comments_excel_file(survey_id, period, submissions):
         ws.cell(row, 2, submission.data['collection']['period'])
         ws.cell(row, 3, boxes_selected)
         ws.cell(row, 4, comment)
+        if survey_id == '134':
+            ws.cell(row, 5, submission.data['data']['300w'])
+            ws.cell(row, 6, submission.data['data']['300f'])
+            ws.cell(row, 7, submission.data['data']['300m'])
+            ws.cell(row, 8, submission.data['data']['300w4'])
+            ws.cell(row, 9, submission.data['data']['300w5'])
+
+            checkboxes = ['91w', '92w1', '92w2', '94w1', '94w2', '95w', '96w', '97w', '91f', '92f1', '92f2', '94f1', '94f2', '95f', '96f', '97f', '191m', '192m1', '192m2', '194m1', '194m2', '195m', '196m', '197m', '191w4', '192w41', '192w42', '194w41', '194w42', '195w4', '196w4', '197w4', '191w5', '192w51', '192w52', '194w51', '194w52', '195w5', '196w5', '197w5']
+            filled_checkboxes = ""
+            for checkbox in checkboxes:
+                if checkbox in submission.data['data']:
+                    filled_checkboxes = filled_checkboxes + f"{checkbox}, "
+            ws.cell(row, 10, filled_checkboxes)
 
     ws.cell(1, 1, f"Survey ID: {survey_id}")
     ws.cell(1, 2, f"Comments found: {surveys_with_comments_count}")
+    if survey_id == '134':
+        ws.cell(1, 5, f"Weekly")
+        ws.cell(1, 6, f"Fortnightly")
+        ws.cell(1, 7, f"Calendar Monthly")
+        ws.cell(1, 8, f"4 Weekly Pay")
+        ws.cell(1, 9, f"5 Weekly Pay")
+
     print(f"{surveys_with_comments_count} out of {len(submissions)} submissions had comments")
 
     parent_dir_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -83,6 +103,8 @@ def get_comment_text(submission):
         return submission.data['data'].get('146h')
     if submission.data['survey_id'] == '187':
         return submission.data['data'].get('500')
+    if submission.data['survey_id'] == '134':
+        return submission.data['data'].get('300')
     return submission.data['data'].get('146')
 
 

--- a/scripts/export_comments.py
+++ b/scripts/export_comments.py
@@ -72,11 +72,11 @@ def create_comments_excel_file(survey_id, period, submissions):
     ws.cell(1, 1, f"Survey ID: {survey_id}")
     ws.cell(1, 2, f"Comments found: {surveys_with_comments_count}")
     if survey_id == '134':
-        ws.cell(1, 5, f"Weekly")
-        ws.cell(1, 6, f"Fortnightly")
-        ws.cell(1, 7, f"Calendar Monthly")
-        ws.cell(1, 8, f"4 Weekly Pay")
-        ws.cell(1, 9, f"5 Weekly Pay")
+        ws.cell(1, 5, "Weekly comment")
+        ws.cell(1, 6, "Fortnightly comment")
+        ws.cell(1, 7, "Calendar Monthly comment")
+        ws.cell(1, 8, "4 Weekly Pay comment")
+        ws.cell(1, 9, "5 Weekly Pay comment")
     print(f"{surveys_with_comments_count} out of {len(submissions)} submissions had comments")
 
     parent_dir_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/scripts/export_comments.py
+++ b/scripts/export_comments.py
@@ -58,7 +58,6 @@ def create_comments_excel_file(survey_id, period, submissions):
                 ws.cell(row, 8, submission.data['data']['300w4'])
             if '300w5' in submission.data['data']:
                 ws.cell(row, 9, submission.data['data']['300w5'])
-
             checkboxes = ['91w', '92w1', '92w2', '94w1', '94w2', '95w', '96w', '97w', '91f', '92f1', '92f2', '94f1', '94f2', '95f', '96f', '97f', '191m', '192m1', '192m2', '194m1', '194m2', '195m', '196m', '197m', '191w4', '192w41', '192w42', '194w41', '194w42', '195w4', '196w4', '197w4', '191w5', '192w51', '192w52', '194w51', '194w52', '195w5', '196w5', '197w5']
             filled_checkboxes = ""
             for checkbox in checkboxes:
@@ -74,7 +73,6 @@ def create_comments_excel_file(survey_id, period, submissions):
         ws.cell(1, 7, f"Calendar Monthly")
         ws.cell(1, 8, f"4 Weekly Pay")
         ws.cell(1, 9, f"5 Weekly Pay")
-
     print(f"{surveys_with_comments_count} out of {len(submissions)} submissions had comments")
 
     parent_dir_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/scripts/export_comments.py
+++ b/scripts/export_comments.py
@@ -61,8 +61,8 @@ def create_comments_excel_file(survey_id, period, submissions):
             checkboxes = ['91w', '92w1', '92w2', '94w1', '94w2', '95w', '96w', '97w',
                           '91f', '92f1', '92f2', '94f1', '94f2', '95f', '96f', '97f',
                           '191m', '192m1', '192m2', '194m1', '194m2', '195m', '196m', '197m',
-                          '191w4', '192w41', '192w42', '194w41', '194w42', '195w4', '196w4',
-                          '197w4', '191w5', '192w51', '192w52', '194w51', '194w52', '195w5', '196w5', '197w5']
+                          '191w4', '192w41', '192w42', '194w41', '194w42', '195w4', '196w4', '197w4',
+                          '191w5', '192w51', '192w52', '194w51', '194w52', '195w5', '196w5', '197w5']
             filled_checkboxes = ""
             for checkbox in checkboxes:
                 if checkbox in submission.data['data']:

--- a/scripts/export_comments.py
+++ b/scripts/export_comments.py
@@ -48,11 +48,16 @@ def create_comments_excel_file(survey_id, period, submissions):
         ws.cell(row, 3, boxes_selected)
         ws.cell(row, 4, comment)
         if survey_id == '134':
-            ws.cell(row, 5, submission.data['data']['300w'])
-            ws.cell(row, 6, submission.data['data']['300f'])
-            ws.cell(row, 7, submission.data['data']['300m'])
-            ws.cell(row, 8, submission.data['data']['300w4'])
-            ws.cell(row, 9, submission.data['data']['300w5'])
+            if '300w' in submission.data['data']:
+                ws.cell(row, 5, submission.data['data']['300w'])
+            if '300f' in submission.data['data']:
+                ws.cell(row, 6, submission.data['data']['300f'])
+            if '300m' in submission.data['data']:
+                ws.cell(row, 7, submission.data['data']['300m'])
+            if '300w4' in submission.data['data']:
+                ws.cell(row, 8, submission.data['data']['300w4'])
+            if '300w5' in submission.data['data']:
+                ws.cell(row, 9, submission.data['data']['300w5'])
 
             checkboxes = ['91w', '92w1', '92w2', '94w1', '94w2', '95w', '96w', '97w', '91f', '92f1', '92f2', '94f1', '94f2', '95f', '96f', '97f', '191m', '192m1', '192m2', '194m1', '194m2', '195m', '196m', '197m', '191w4', '192w41', '192w42', '194w41', '194w42', '195w4', '196w4', '197w4', '191w5', '192w51', '192w52', '194w51', '194w52', '195w5', '196w5', '197w5']
             filled_checkboxes = ""

--- a/scripts/export_comments.py
+++ b/scripts/export_comments.py
@@ -45,8 +45,6 @@ def create_comments_excel_file(survey_id, period, submissions):
         surveys_with_comments_count += 1
         ws.cell(row, 1, submission.data['metadata']['ru_ref'])
         ws.cell(row, 2, submission.data['collection']['period'])
-        ws.cell(row, 3, boxes_selected)
-        ws.cell(row, 4, comment)
         if survey_id == '134':
             if '300w' in submission.data['data']:
                 ws.cell(row, 5, submission.data['data']['300w'])
@@ -63,11 +61,12 @@ def create_comments_excel_file(survey_id, period, submissions):
                           '191m', '192m1', '192m2', '194m1', '194m2', '195m', '196m', '197m',
                           '191w4', '192w41', '192w42', '194w41', '194w42', '195w4', '196w4', '197w4',
                           '191w5', '192w51', '192w52', '194w51', '194w52', '195w5', '196w5', '197w5']
-            filled_checkboxes = ""
             for checkbox in checkboxes:
                 if checkbox in submission.data['data']:
-                    filled_checkboxes = filled_checkboxes + f"{checkbox}, "
-            ws.cell(row, 10, filled_checkboxes)
+                    boxes_selected = boxes_selected + f"{checkbox}, "
+        ws.cell(row, 3, boxes_selected)
+        ws.cell(row, 4, comment)
+
 
     ws.cell(1, 1, f"Survey ID: {survey_id}")
     ws.cell(1, 2, f"Comments found: {surveys_with_comments_count}")


### PR DESCRIPTION
## What? and Why?
The significant changes script needed to handle MWSS, including the checkboxes

## Checklist

- The `get_comment_text` function grabs the general comment text from Q-code `300` if the survey_id is 134 (MWSS).

- The `create_comments_excel_file` function adds the comments for the other mini-surveys (along with headings to tell them apart), as well as the Q-codes for the checkboxes that have been filled in on the submission.

## How to test

- Set up a virtual environment for the SDX services if you haven't already.

- Go to your sdx-compose and run `make start` to get the SDX services up.

- In your browser, type localhost/FTP into the URL bar to access the SDX console.

- Log in, and then, on the Store tab, generate dummy survey submissions for 134. Preferably, include multiple submissions, changing the tx_id each time so you don't overwrite the earlier submissions. Feel free to modify the comments and checkboxes (see Trello card), as well. Make sure you keep the period as the default (201605).

- Go to sdx-store, then into the `/scripts` folder. Run the command `python3 export_comments.py 134 201605`. This will generate an excel file in the sdx-store root folder titled something like `134_201605.xlsx`.

- Open this excel file and you should see the submissions and their respective comments and checkboxes.

## Links

[Trello card](https://trello.com/c/4iFLsc5b)
