### PR TITLE
changed 146h to 146

### DIFF
--- a/scripts/export_comments.py
+++ b/scripts/export_comments.py
@@ -105,7 +105,7 @@ def get_comment_text(submission):
     on the survey
     """
     if submission.data['survey_id'] == '009':
-        return submission.data['data'].get('146h')
+        return submission.data['data'].get('146')
     if submission.data['survey_id'] == '187':
         return submission.data['data'].get('500')
     if submission.data['survey_id'] == '134':


### PR DESCRIPTION
## What? and Why?
The 146(x) MBS qcodes are being retired and replaced with a singular 146 qcode, so a very minor change needed to be made to export_comments.py

## Links
[Trello card](https://trello.com/c/KPW0QBkkl)
